### PR TITLE
#26 fix Terminal commands doesn't work when having spaces in between commands

### DIFF
--- a/src/components/apps/terminal.js
+++ b/src/components/apps/terminal.js
@@ -174,7 +174,7 @@ export class Terminal extends Component {
     }
 
     handleCommands = (command, rowId) => {
-        let words = command.split(' ');
+        let words = command.split(' ').filter(Boolean);
         let main = words[0];
         words.shift()
         let result = "";
@@ -228,7 +228,7 @@ export class Terminal extends Component {
                     result = `ls: cannot access '${words}': No such file or directory                    `;
                 }
                 break;
-            case "mkdir" : 
+            case "mkdir":
                 if(words[0]!==undefined && words[0]!==""){
                     this.props.addFolder(words[0]); 
                     result="";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12570521/116535589-8a94c880-a901-11eb-8f4b-437677c4052b.png)
